### PR TITLE
Fix CMake minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.12)
 project(sjasmplus)
 
 SET(SJASMPLUS_VERSION 20190306.1+++WiP)


### PR DESCRIPTION
list TRANSFORM requires at least CMake 3.12 so the current minimum version of 3.7 is incorrect